### PR TITLE
Fix unused icon import

### DIFF
--- a/src/components/ai/ChatDrawer.tsx
+++ b/src/components/ai/ChatDrawer.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import GlassCard from '@/components/GlassCard';
-import { MessageCircle, Send, Sparkles, X } from 'lucide-react';
+import { MessageCircle, Send, Sparkles } from 'lucide-react';
 import { mockAiService, ChatMessage } from '@/services/mockAiService';
 
 interface ChatDrawerProps {


### PR DESCRIPTION
## Summary
- remove unused `X` icon import in ChatDrawer

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dcd8c77b88328aa11b81d155baed8