### PR TITLE
Fix ChatDrawer quick actions

### DIFF
--- a/src/components/ai/ChatDrawer.tsx
+++ b/src/components/ai/ChatDrawer.tsx
@@ -92,7 +92,7 @@ const ChatDrawer = ({ userContext }: ChatDrawerProps) => {
                       onClick={() => setInputValue(action)}
                       className="block w-full text-left p-2 text-sm text-blue-400 hover:bg-white/5 rounded-lg transition-colors"
                     >
-                      "{action}"
+                      {action}
                     </button>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- fix quick action button text so it renders without quotes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dcd89cb60832896d52c219de5631e