### PR TITLE
Migrate CSS variables to vueniTheme

### DIFF
--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -40,8 +40,7 @@ export {
   VueniSkeleton,
   VueniContainer,
   VueniSection,
-  VueniGrid,
-  vueniTokens
+  VueniGrid
 } from './VueniDesignSystem';
 export type {
   VueniGlassCardProps,

--- a/src/index.css
+++ b/src/index.css
@@ -14,49 +14,6 @@
 
 /* Definition of the design system. All colors, gradients, fonts, etc should be defined here. */
 
-@layer base {
-  :root {
-    --radius: 0.5rem;
-  }
-
-  .dark {
-    --background: 0 0% 0%;
-    --foreground: 210 40% 98%;
-
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
-}
 
 @layer base {
   * {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -31,6 +31,7 @@ import './index.css'
 import './app/styles/scroll-fix.css' // WHY: Critical fix for double scroll issue - must load after index.css
 import { SecurityEnvValidator } from './shared/utils/envValidation'
 import './telemetry/vitals.ts' // Initialize performance monitoring
+import { VueniThemeProvider } from './theme/ThemeProvider'
 
 // Validate security environment before app startup
 try {
@@ -56,9 +57,8 @@ ${errorMessage}
   throw new Error('Security configuration error');
 }
 
-// Add dark mode class to document by default
-document.documentElement.classList.add('dark');
-
 createRoot(document.getElementById("root")!).render(
-  <App />
+  <VueniThemeProvider>
+    <App />
+  </VueniThemeProvider>
 );

--- a/src/shared/ui/ContextMenu.tsx
+++ b/src/shared/ui/ContextMenu.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
 import { cn } from '@/shared/lib/utils';
-import { vueniTokens } from '@/components/shared/VueniDesignSystem';
 
 // Context Menu Root
 export const ContextMenu = ContextMenuPrimitive.Root;


### PR DESCRIPTION
## Summary
- remove leftover color variables from `index.css`
- setup `VueniThemeProvider` in `main.tsx`
- drop unused `vueniTokens` import and export

## Testing
- `npm run test:run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d043d9d88328a5d792c6ebdade51