### PR TITLE
Ensure scroll provider wraps routing

### DIFF
--- a/src/navigation/__tests__/AdaptiveNavigation.test.tsx
+++ b/src/navigation/__tests__/AdaptiveNavigation.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { render, screen, act } from '@testing-library/react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import AdaptiveNavigation from '../components/AdaptiveNavigation';
 import { useBreakpoint } from '@/shared/hooks/useBreakpoint';
 
@@ -148,5 +148,33 @@ describe('AdaptiveNavigation', () => {
     expect(screen.getByTestId('sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('top-bar')).toBeInTheDocument();
     expect(screen.queryByTestId('nav-rail')).not.toBeInTheDocument();
+  });
+
+  it('keeps TopBar mounted across route changes on desktop', () => {
+    mockUseBreakpoint.mockReturnValue({
+      breakpoint: 'desktop',
+      isMobile: false,
+      isTablet: false,
+      isDesktop: true,
+      isLargeDesktop: false,
+    });
+
+    render(
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<AdaptiveNavigation />} />
+          <Route path="/next" element={<AdaptiveNavigation />} />
+        </Routes>
+      </BrowserRouter>
+    );
+
+    expect(screen.getByTestId('top-bar')).toBeInTheDocument();
+
+    act(() => {
+      window.history.pushState({}, '', '/next');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    expect(screen.getByTestId('top-bar')).toBeInTheDocument();
   });
 }); 

--- a/src/navigation/examples/iOS26NavBarDemo.tsx
+++ b/src/navigation/examples/iOS26NavBarDemo.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
+import { ScrollControllerProvider } from '@/navigation/context/ScrollControllerContext';
 import iOS26NavBar from '../components/iOS26NavBar';
 import { 
   Home, 
@@ -158,16 +159,18 @@ const NavigationDemo: React.FC = () => {
  */
 const iOS26NavBarDemo: React.FC = () => {
   return (
-    <BrowserRouter>
-      <div className="min-h-screen bg-black">
-        {/* Import navigation styles */}
-        <style>
-          {`@import url('/src/app/styles/nav-styles.css');`}
-        </style>
-        
-        <NavigationDemo />
-      </div>
-    </BrowserRouter>
+    <ScrollControllerProvider>
+      <BrowserRouter>
+        <div className="min-h-screen bg-black">
+          {/* Import navigation styles */}
+          <style>
+            {`@import url('/src/app/styles/nav-styles.css');`}
+          </style>
+
+          <NavigationDemo />
+        </div>
+      </BrowserRouter>
+    </ScrollControllerProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap iOS nav demo with `ScrollControllerProvider`
- confirm `ScrollControllerProvider` is the top-level wrapper in `App.tsx`
- extend `AdaptiveNavigation` tests to keep `TopBar` mounted across route changes

## Testing
- `npm test -- -t "AdaptiveNavigation"` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d0459b808328b768bc1e28a222c3