### PR TITLE
Add hydration tracker widget

### DIFF
--- a/src/features/analytics/components/AnalyticsPage.tsx
+++ b/src/features/analytics/components/AnalyticsPage.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/shared/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
 import { cn } from '@/shared/lib/utils';
 import { useIsMobile } from '@/shared/hooks/use-mobile';
+import HydrationTracker from './health/HydrationTracker';
 import { analyticsService } from '../api/analyticsService';
 import { AnalyticsDashboardData, AnalyticsTimeframe } from '@/shared/types/analytics';
 import { unifiedDataManager, useUnifiedState } from '@/services/unifiedDataManager';
@@ -410,6 +411,12 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
           Last updated: {new Date(dashboardData.lastUpdated).toLocaleString()}
         </span>
       </div>
+
+      {isMobile && (
+        <div className="py-2">
+          <HydrationTracker />
+        </div>
+      )}
 
       {/* Connected Devices */}
       <UniversalCard variant="glass" interactive className="p-4 sm:p-6">

--- a/src/features/analytics/components/health/HydrationTracker.tsx
+++ b/src/features/analytics/components/health/HydrationTracker.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+import { Droplet } from 'lucide-react';
+import { toast } from '@/shared/ui/sonner';
+import { useHydrationStore } from '../../store/hydration';
+
+const TOTAL_GLASSES = 8;
+
+export const HydrationTracker: React.FC = () => {
+  const { count, increment, checkReminder, remind, dismissReminder } = useHydrationStore();
+
+  useEffect(() => {
+    checkReminder();
+  }, [checkReminder]);
+
+  useEffect(() => {
+    if (remind) {
+      toast({ title: 'Drink up & bank $2…' });
+      dismissReminder();
+    }
+  }, [remind, dismissReminder]);
+
+  return (
+    <div className="flex items-center space-x-1">
+      {Array.from({ length: TOTAL_GLASSES }).map((_, i) => (
+        <button
+          key={i}
+          onClick={() => increment()}
+          className="focus:outline-none"
+        >
+          <Droplet
+            className={`w-5 h-5 ${i < count ? 'text-blue-400' : 'text-white/20'}`}
+            fill={i < count ? 'currentColor' : 'none'}
+          />
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default HydrationTracker;

--- a/src/features/analytics/store/hydration.ts
+++ b/src/features/analytics/store/hydration.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+interface HydrationState {
+  count: number;
+  lastReset: number;
+  remind: boolean;
+  increment: () => void;
+  reset: () => void;
+  checkReminder: () => void;
+  dismissReminder: () => void;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const useHydrationStore = create<HydrationState>((set, get) => ({
+  count: 0,
+  lastReset: Date.now(),
+  remind: false,
+  increment: () => {
+    const { count } = get();
+    set({ count: count + 1 });
+  },
+  reset: () => set({ count: 0, lastReset: Date.now() }),
+  checkReminder: () => {
+    const { count, lastReset } = get();
+    const now = new Date();
+    if (now.getTime() - lastReset > DAY_MS) {
+      set({ count: 0, lastReset: now.getTime() });
+    }
+    if (now.getHours() >= 18 && get().count < 4) {
+      set({ remind: true });
+    }
+  },
+  dismissReminder: () => set({ remind: false })
+}));


### PR DESCRIPTION
## Summary
- add hydration store for tracking glasses of water
- create hydration tracker component showing droplet meter and reminder toast
- insert hydration tracker in mobile layout of analytics page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d5a9801c8328a32f1f499d05f021