### PR TITLE
Add Daily Activity Rings widget

### DIFF
--- a/src/data/health/index.ts
+++ b/src/data/health/index.ts
@@ -1,0 +1,7 @@
+import { activityRings, ActivityRingData } from '@/mocks/health/activity';
+
+export const getActivityRings = async (): Promise<ActivityRingData[]> => {
+  return activityRings;
+};
+
+export type { ActivityRingData };

--- a/src/features/analytics/components/AnalyticsPage.tsx
+++ b/src/features/analytics/components/AnalyticsPage.tsx
@@ -9,6 +9,7 @@ import { useIsMobile } from '@/shared/hooks/use-mobile';
 import { analyticsService } from '../api/analyticsService';
 import { AnalyticsDashboardData, AnalyticsTimeframe } from '@/shared/types/analytics';
 import { unifiedDataManager, useUnifiedState } from '@/services/unifiedDataManager';
+import DailyActivityRings from './health/DailyActivityRings';
 
 // Note: Chart components and specialized widgets will be implemented in Phase 3
 
@@ -710,7 +711,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
       )}
 
       {/* Device-Specific Health Metrics */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className={`grid grid-cols-1 md:grid-cols-2 ${isMobile ? 'lg:grid-cols-3' : 'lg:grid-cols-4'} gap-6`}>
         <UniversalCard variant="glass" interactive className="p-6">
           <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
             <Heart className="w-5 h-5 text-red-400" />
@@ -847,6 +848,7 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
             </div>
           </div>
         </UniversalCard>
+        {!isMobile && <DailyActivityRings />}
       </div>
 
       {/* Financial Health Correlation */}

--- a/src/features/analytics/components/health/DailyActivityRings.tsx
+++ b/src/features/analytics/components/health/DailyActivityRings.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { Target } from 'lucide-react';
+import AnimatedCircularProgress from '@/shared/ui/charts/AnimatedCircularProgress';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/button';
+import { getActivityRings, ActivityRingData } from '@/data/health';
+
+const DailyActivityRings: React.FC = () => {
+  const [rings, setRings] = useState<ActivityRingData[]>([]);
+
+  useEffect(() => {
+    getActivityRings().then(setRings).catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="bg-white/[0.02] border border-white/[0.05] rounded-xl p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+          <Target className="w-5 h-5 text-yellow-400" />
+          Activity Rings
+        </h3>
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="ghost" size="sm" className="text-white/60 hover:text-white">
+              Compare
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="bg-black/90 border-white/[0.08] max-w-sm">
+            <DialogHeader>
+              <DialogTitle>Activity Ring Comparison</DialogTitle>
+            </DialogHeader>
+            <div className="flex justify-around py-4">
+              {rings.map((ring) => (
+                <div key={ring.id} className="text-center">
+                  <AnimatedCircularProgress
+                    value={ring.value}
+                    maxValue={ring.goal}
+                    color={ring.color}
+                    size={90}
+                  />
+                  <div className="mt-2 text-sm text-white">
+                    {ring.value}/{ring.goal}
+                  </div>
+                  <div className="text-xs text-white/60">{ring.label}</div>
+                </div>
+              ))}
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+      <div className="flex items-center justify-around">
+        {rings.map((ring) => (
+          <div key={ring.id} className="flex flex-col items-center">
+            <AnimatedCircularProgress
+              value={ring.value}
+              maxValue={ring.goal}
+              color={ring.color}
+              size={70}
+            />
+            <span className="text-xs text-white mt-1">{ring.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DailyActivityRings;

--- a/src/mocks/health/activity.ts
+++ b/src/mocks/health/activity.ts
@@ -1,0 +1,13 @@
+export interface ActivityRingData {
+  id: 'move' | 'exercise' | 'stand';
+  label: string;
+  value: number;
+  goal: number;
+  color: string;
+}
+
+export const activityRings: ActivityRingData[] = [
+  { id: 'move', label: 'Move', value: 420, goal: 500, color: '#ef4444' },
+  { id: 'exercise', label: 'Exercise', value: 22, goal: 30, color: '#22c55e' },
+  { id: 'stand', label: 'Stand', value: 10, goal: 12, color: '#3b82f6' }
+];


### PR DESCRIPTION
## Summary
- mock activity ring data for Move, Exercise and Stand
- expose `getActivityRings` helper
- new `DailyActivityRings` component using AnimatedCircularProgress and Radix Dialog
- show activity rings on analytics page for non-mobile screens

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6855d5a545fc83288c0a8b02b3db66de