### PR TITLE
Add mindfulness scatterplot component

### DIFF
--- a/src/data/health/index.ts
+++ b/src/data/health/index.ts
@@ -1,0 +1,10 @@
+import mindfulSpending from '@/mocks/health/mindfulSpending';
+
+export interface MindfulnessVsSpendingPoint {
+  mindful: number;
+  stdDev: number;
+}
+
+export function getMindfulnessVsSpending(): MindfulnessVsSpendingPoint[] {
+  return mindfulSpending;
+}

--- a/src/features/analytics/components/AnalyticsPage.tsx
+++ b/src/features/analytics/components/AnalyticsPage.tsx
@@ -9,6 +9,7 @@ import { useIsMobile } from '@/shared/hooks/use-mobile';
 import { analyticsService } from '../api/analyticsService';
 import { AnalyticsDashboardData, AnalyticsTimeframe } from '@/shared/types/analytics';
 import { unifiedDataManager, useUnifiedState } from '@/services/unifiedDataManager';
+import MindfulnessVsSpending from './health/MindfulnessVsSpending';
 
 // Note: Chart components and specialized widgets will be implemented in Phase 3
 
@@ -761,6 +762,8 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
             </div>
           </div>
         </UniversalCard>
+
+        <MindfulnessVsSpending />
 
         <UniversalCard variant="glass" interactive className="p-6">
           <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">

--- a/src/features/analytics/components/health/MindfulnessVsSpending.tsx
+++ b/src/features/analytics/components/health/MindfulnessVsSpending.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useMemo } from 'react';
+import { ScatterPlot } from '@/shared/ui/charts';
+import { getMindfulnessVsSpending } from '@/data/health';
+import { toast } from '@/shared/ui/use-toast';
+
+export const MindfulnessVsSpending: React.FC = () => {
+  const data = useMemo(() => getMindfulnessVsSpending(), []);
+
+  useEffect(() => {
+    const total = data.reduce((sum, d) => sum + d.mindful, 0);
+    if (total < 40) {
+      toast({
+        title: 'Low mindfulness activity',
+        description: 'Try increasing mindful minutes to stabilize spending.'
+      });
+    }
+  }, [data]);
+
+  const scatterData = data.map(d => ({ date: d.mindful, stdDev: d.stdDev }));
+
+  return (
+    <ScatterPlot
+      data={scatterData}
+      series={[{ dataKey: 'stdDev', label: 'Spending SD', color: '#3b82f6' }]}
+      xAxis={{ show: true, dataKey: 'date', type: 'number' }}
+      yAxis={{ show: true, dataKey: 'stdDev', type: 'number' }}
+      title="Mindfulness vs Spending"
+    />
+  );
+};
+
+export default MindfulnessVsSpending;

--- a/src/mocks/health/mindfulSpending.ts
+++ b/src/mocks/health/mindfulSpending.ts
@@ -1,0 +1,16 @@
+export interface MindfulSpendingPoint {
+  mindful: number;
+  stdDev: number;
+}
+
+const mindfulSpending: MindfulSpendingPoint[] = [
+  { mindful: 6, stdDev: 120 },
+  { mindful: 5, stdDev: 130 },
+  { mindful: 4, stdDev: 125 },
+  { mindful: 3, stdDev: 150 },
+  { mindful: 8, stdDev: 110 },
+  { mindful: 7, stdDev: 100 },
+  { mindful: 5, stdDev: 115 }
+];
+
+export default mindfulSpending;

--- a/src/shared/ui/charts/GraphBase.tsx
+++ b/src/shared/ui/charts/GraphBase.tsx
@@ -19,6 +19,7 @@ import {
   LineChart,
   AreaChart,
   BarChart,
+  ScatterChart,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -27,6 +28,7 @@ import {
   Line,
   Area,
   Bar,
+  Scatter,
   Cell
 } from 'recharts';
 import { cn } from '@/shared/lib/utils';
@@ -542,7 +544,7 @@ export const GraphBase = forwardRef<ChartRef, GraphBaseProps>(({
       <>
         {xAxis.show && (
           <XAxis
-            dataKey="date"
+            dataKey={xAxis.dataKey || 'date'}
             axisLine={false}
             tickLine={false}
             tick={{ 
@@ -555,9 +557,10 @@ export const GraphBase = forwardRef<ChartRef, GraphBaseProps>(({
             scale={xAxis.scale}
           />
         )}
-        {yAxis.show && (
-          <YAxis
-            axisLine={false}
+          {yAxis.show && (
+            <YAxis
+              dataKey={yAxis.dataKey}
+              axisLine={false}
             tickLine={false}
             tick={{ 
               fontSize: appleGraphTokens.typography.fontSize.axisLabel,
@@ -698,6 +701,23 @@ export const GraphBase = forwardRef<ChartRef, GraphBaseProps>(({
               />
             ))}
           </BarChart>
+        );
+
+      case 'scatter':
+        return (
+          <ScatterChart {...commonProps}>
+            {renderGrid()}
+            {renderAxis()}
+            {renderTooltip()}
+            {renderLegend()}
+            {computedSeries.map((serie) => (
+              <Scatter
+                key={serie.dataKey}
+                dataKey={serie.dataKey}
+                fill={serie.color}
+              />
+            ))}
+          </ScatterChart>
         );
 
       default:

--- a/src/shared/ui/charts/ScatterPlot.tsx
+++ b/src/shared/ui/charts/ScatterPlot.tsx
@@ -1,0 +1,16 @@
+import React, { memo, forwardRef, useImperativeHandle, useRef } from 'react';
+import { GraphBase } from './GraphBase';
+import { GraphBaseProps, ChartRef } from './types';
+
+export interface ScatterPlotProps extends Omit<GraphBaseProps, 'type'> {}
+
+export const ScatterPlot = forwardRef<ChartRef, ScatterPlotProps>((props, ref) => {
+  const internalRef = useRef<HTMLDivElement>(null);
+  useImperativeHandle(ref, () => internalRef.current as HTMLDivElement);
+
+  return <GraphBase ref={internalRef} type="scatter" {...props} />;
+});
+
+ScatterPlot.displayName = 'ScatterPlot';
+
+export default memo(ScatterPlot);

--- a/src/shared/ui/charts/index.ts
+++ b/src/shared/ui/charts/index.ts
@@ -10,6 +10,7 @@ export { default as GraphBase } from './GraphBase';
 export { default as LineChart } from './LineChart';
 export { default as AreaChart } from './AreaChart';
 export { default as StackedBarChart } from './StackedBarChart';
+export { default as ScatterPlot } from './ScatterPlot';
 
 // Time range components
 export { default as TimeRangeToggle } from './TimeRangeToggle';
@@ -61,6 +62,11 @@ export type {
   StackedBarDataPoint
 } from './StackedBarChart';
 
+// ScatterPlot-specific types
+export type {
+  ScatterPlotProps
+} from './ScatterPlot';
+
 // TimeRangeToggle-specific types
 export type {
   TimeRangeToggleProps,
@@ -76,7 +82,7 @@ export type {
 export type { ChartConfig } from '@/shared/ui/chart';
 
 // Utility constants
-export const CHART_TYPES = ['line', 'area', 'bar', 'stackedBar'] as const;
+export const CHART_TYPES = ['line', 'area', 'bar', 'stackedBar', 'scatter'] as const;
 export const TIME_RANGES = ['1W', '1M', '3M', '6M', '1Y', 'ALL'] as const;
 
 // Default configurations

--- a/src/shared/ui/charts/types.ts
+++ b/src/shared/ui/charts/types.ts
@@ -6,7 +6,7 @@
 import { ComponentProps } from 'react';
 
 // Core chart types supported by GraphBase
-export type ChartType = 'line' | 'area' | 'bar' | 'stackedBar';
+export type ChartType = 'line' | 'area' | 'bar' | 'stackedBar' | 'scatter';
 
 // Time range options for financial charts
 export type TimeRangeOption = '1W' | '1M' | '3M' | '6M' | '1Y' | 'ALL';
@@ -118,6 +118,7 @@ export interface GridConfig {
 // Axis configuration
 export interface AxisConfig {
   show?: boolean;
+  dataKey?: string;
   tickCount?: number;
   tickSize?: number;
   tickFormatter?: (value: any) => string;


### PR DESCRIPTION
## Summary
- add mindful spending mock data
- expose `getMindfulnessVsSpending` helper
- implement ScatterPlot primitive and support in GraphBase
- show mindfulness vs spending chart in analytics page

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d5a7411083289d4910aaf6d9766a