### PR TITLE
Add resting heart rate trend chart

### DIFF
--- a/src/data/health/index.ts
+++ b/src/data/health/index.ts
@@ -1,0 +1,6 @@
+import { restingHeartRate30d } from '@/mocks/health/restingHeartRate';
+import { AnalyticsDataPoint } from '@/shared/types/analytics';
+
+export const getRestingHeartRateTrend = (): AnalyticsDataPoint[] => {
+  return restingHeartRate30d;
+};

--- a/src/features/analytics/components/AnalyticsPage.tsx
+++ b/src/features/analytics/components/AnalyticsPage.tsx
@@ -10,6 +10,8 @@ import { analyticsService } from '../api/analyticsService';
 import { AnalyticsDashboardData, AnalyticsTimeframe } from '@/shared/types/analytics';
 import { unifiedDataManager, useUnifiedState } from '@/services/unifiedDataManager';
 
+const RestingHeartRateTrend = React.lazy(() => import('./health/RestingHeartRateTrend'));
+
 // Note: Chart components and specialized widgets will be implemented in Phase 3
 
 export interface AnalyticsPageProps {
@@ -1133,9 +1135,10 @@ export const AnalyticsPage: React.FC<AnalyticsPageProps> = ({
               </div>
             </div>
           </div>
-        </UniversalCard>
+          </UniversalCard>
+        </div>
+        <RestingHeartRateTrend />
       </div>
-    </div>
   );
 };
 

--- a/src/features/analytics/components/health/RestingHeartRateTrend.tsx
+++ b/src/features/analytics/components/health/RestingHeartRateTrend.tsx
@@ -1,0 +1,50 @@
+import React, { useMemo } from 'react';
+import { LineChart } from '@/shared/ui/charts';
+import { Badge } from '@/shared/ui/badge';
+import { UniversalCard } from '@/shared/ui/UniversalCard';
+import { Heart } from 'lucide-react';
+import { getRestingHeartRateTrend } from '@/data/health';
+
+const RestingHeartRateTrend: React.FC = () => {
+  const data = useMemo(() => getRestingHeartRateTrend(), []);
+
+  const trend = data[data.length - 1].value - data[0].value;
+  const chipClass = trend <= 0
+    ? 'border-green-400/20 text-green-400'
+    : 'border-red-400/20 text-red-400';
+  const chipLabel = trend <= 0 ? 'Improving' : 'Rising';
+
+  const chartData = data.map(d => ({ date: d.timestamp.split('T')[0], value: d.value }));
+
+  return (
+    <UniversalCard variant="glass" interactive className="p-6">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <Heart className="w-5 h-5 text-red-400" />
+        Resting Heart Rate
+      </h3>
+      <div className="relative">
+        <div className="absolute inset-0 flex flex-col pointer-events-none">
+          <div className="flex-1 bg-red-400/10" />
+          <div className="flex-1 bg-yellow-400/10" />
+          <div className="flex-1 bg-green-400/10" />
+        </div>
+        <LineChart
+          data={chartData}
+          series={[{ dataKey: 'value', label: 'BPM', color: '#60a5fa' }]}
+          dimensions={{ height: 200, responsive: true }}
+          legend={{ show: false }}
+          className="relative z-10"
+          lineConfig={{ smoothLines: true, showDots: false }}
+        />
+        <Badge
+          variant="outline"
+          className={`absolute top-2 right-2 z-20 text-xs ${chipClass}`}
+        >
+          {chipLabel}
+        </Badge>
+      </div>
+    </UniversalCard>
+  );
+};
+
+export default RestingHeartRateTrend;

--- a/src/mocks/health/restingHeartRate.ts
+++ b/src/mocks/health/restingHeartRate.ts
@@ -1,0 +1,14 @@
+import { AnalyticsDataPoint } from '@/shared/types/analytics';
+
+const today = new Date();
+
+export const restingHeartRate30d: AnalyticsDataPoint[] = Array.from({ length: 30 }).map((_, i) => {
+  const date = new Date(today);
+  date.setDate(today.getDate() - (29 - i));
+  const base = 60 + Math.sin(i / 5) * 3;
+  const variation = (Math.random() - 0.5) * 2;
+  return {
+    timestamp: date.toISOString(),
+    value: Math.round(base + variation)
+  };
+});


### PR DESCRIPTION
## Summary
- add mock data for 30-day resting heart rate
- expose `getRestingHeartRateTrend` helper
- show trend line chart with zones and insight chip
- lazy load new component in analytics page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855d5a5edf88328987d38cc4408c502