### PR TITLE
Add hover effect to AgeOfMoneyCard

### DIFF
--- a/src/features/age-of-money/components/AgeOfMoneyCard.tsx
+++ b/src/features/age-of-money/components/AgeOfMoneyCard.tsx
@@ -23,6 +23,7 @@ export const AgeOfMoneyCard: React.FC = () => {
       iconColor="#06b6d4"
       score={metric ? Math.min(metric.averageDaysHeld, 100) : undefined}
       orientation="vertical"
+      interactive
     >
       {!metric && (
         <div className="text-center">


### PR DESCRIPTION
## Summary
- enable interactive prop on AgeOfMoneyCard so `card-hover` styles trigger

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685621cf16ec8328a984b175c5d63416