### PR TITLE
Add pfm-row utility and unify list item layout

### DIFF
--- a/src/app/styles/pfm-row.css
+++ b/src/app/styles/pfm-row.css
@@ -1,0 +1,5 @@
+@layer components {
+  .pfm-row {
+    @apply flex w-full items-center min-h-[56px] py-2;
+  }
+}

--- a/src/features/bank-linking/components/BankLinkingPanel.tsx
+++ b/src/features/bank-linking/components/BankLinkingPanel.tsx
@@ -229,7 +229,7 @@ export const BankLinkingPanel: React.FC = () => {
         {MOCK_ACCOUNTS.map((account) => (
           <div
             key={account.id}
-            className="flex items-center justify-between p-1.5 bg-white/[0.02] rounded-lg border border-white/[0.05] hover:bg-white/[0.04] transition-all cursor-pointer"
+            className="pfm-row justify-between px-1.5 bg-white/[0.02] rounded-lg border border-white/[0.05] hover:bg-white/[0.04] transition-all cursor-pointer"
           >
             <div className="flex items-center gap-2">
               <div className="w-5 h-5 rounded-lg bg-white/[0.05] flex items-center justify-center">

--- a/src/features/subscriptions/components/RecurringChargesList.tsx
+++ b/src/features/subscriptions/components/RecurringChargesList.tsx
@@ -116,9 +116,9 @@ export const RecurringChargesList: React.FC<{ className?: string }> = ({
         {charges.map((charge) => (
           <div
             key={charge.id}
-            className="p-2 bg-white/[0.02] rounded-lg border border-white/[0.05] hover:bg-white/[0.04] transition-all"
+            className="pfm-row flex-col sm:flex-row px-2 bg-white/[0.02] rounded-lg border border-white/[0.05] hover:bg-white/[0.04] transition-all"
           >
-            <div className="flex items-center justify-between mb-1">
+            <div className="flex items-center justify-between w-full sm:w-auto mb-1 sm:mb-0">
               <h4 className="text-xs font-medium text-white truncate">
                 {charge.merchantName}
               </h4>
@@ -131,8 +131,7 @@ export const RecurringChargesList: React.FC<{ className?: string }> = ({
                 </p>
               </div>
             </div>
-
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between w-full sm:w-auto">
               <div className="flex items-center gap-1">
                 <Calendar className="w-3 h-3 text-white/40" />
                 <span className="text-xs text-white/60">

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
 @import './app/styles/viewport-guardian.css'; /* Viewport Guardian utilities */
 @import './app/styles/card-interactions.css';
 @import './app/styles/accessibility.css';
+@import './app/styles/pfm-row.css';
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- define `pfm-row` component class for common row styling
- apply `pfm-row` to account and subscription list items
- import the new global style

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*


------
https://chatgpt.com/codex/tasks/task_e_6856277485a48328b2bc9358fcf0e1af