### PR TITLE
Fix crash when merchant undefined

### DIFF
--- a/src/components/TransactionItem.tsx
+++ b/src/components/TransactionItem.tsx
@@ -109,7 +109,13 @@ const TransactionItem = React.memo<TransactionItemProps>(
               ) : (
                 <div className="w-7 h-7 rounded-lg bg-blue-500/20 flex items-center justify-center">
                   <span className="text-blue-400 text-xs font-bold">
-                    {transaction.merchant.charAt(0).toUpperCase()}
+                    {(
+                      (transaction as any).merchant ??
+                      (transaction as any).merchantName ??
+                      '?'
+                    )
+                      .charAt(0)
+                      .toUpperCase()}
                   </span>
                 </div>
               )}

--- a/src/features/transactions/components/UnifiedTransactionList.tsx
+++ b/src/features/transactions/components/UnifiedTransactionList.tsx
@@ -534,7 +534,13 @@ const TransactionItem = React.memo<{
           )}
           style={{ backgroundColor: transaction.category.color + '30' }}
         >
-          {transaction.merchant.charAt(0).toUpperCase()}
+          {(
+            (transaction as any).merchant ??
+            (transaction as any).merchantName ??
+            '?'
+          )
+            .charAt(0)
+            .toUpperCase()}
         </div>
 
         {/* Transaction Details */}


### PR DESCRIPTION
## Summary
- avoid crashing when transactions omit the `merchant` field
- fall back to `merchantName` or a placeholder when deriving merchant initials

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c205a1b88328a0a37bb18652eb6f