### PR TITLE
Remove top nav styles

### DIFF
--- a/src/app/styles/responsive-enhancements.css
+++ b/src/app/styles/responsive-enhancements.css
@@ -808,25 +808,6 @@ html:not(.dark) [class*='text-muted'] {
   }
 }
 
-/* Top navigation bar responsive improvements */
-.top-nav-responsive {
-  /* Mobile: Compact padding */
-  padding: 0.5rem;
-}
-
-@media (min-width: 640px) {
-  .top-nav-responsive {
-    /* Tablet: Medium padding */
-    padding: 1rem;
-  }
-}
-
-@media (min-width: 1024px) {
-  .top-nav-responsive {
-    /* Desktop: Standard padding */
-    padding: 1rem 1.5rem;
-  }
-}
 
 /* Prevent overflow on small screens */
 .nav-overflow-hidden {

--- a/src/app/styles/viewport-guardian.css
+++ b/src/app/styles/viewport-guardian.css
@@ -251,15 +251,6 @@
   z-index: 50;
 }
 
-/* Top navigation with safe area support */
-.top-nav-safe {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  padding-top: env(safe-area-inset-top, var(--safe-area-inset-top, 0px));
-  z-index: 50;
-}
 
 /* Content area that accounts for fixed navigation */
 .content-with-nav {


### PR DESCRIPTION
## Summary
- delete `.top-nav-safe` rule from `viewport-guardian.css`
- remove `.top-nav-responsive` styling block in `responsive-enhancements.css`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c6d0d4c8832890bdef933014c890