### PR TITLE
Use centralized mock data provider

### DIFF
--- a/src/features/bank-linking/components/BankLinkingPanel.tsx
+++ b/src/features/bank-linking/components/BankLinkingPanel.tsx
@@ -9,7 +9,8 @@ import {
 } from 'lucide-react';
 import { formatCurrency } from '@/shared/utils/formatters';
 import { cn } from '@/shared/lib/utils';
-import { mockAccountsEnhanced, mockInstitutions } from '@/services/mockData';
+import { mockInstitutions } from '@/services/mockData';
+import { getAccounts } from '@/services/mockDataProvider';
 
 interface MockAccount {
   id: string;
@@ -35,8 +36,8 @@ interface MockAccount {
 }
 
 // Transform enhanced mock data to panel format
-const transformMockAccounts = (): MockAccount[] => {
-  return mockAccountsEnhanced.map((account, index) => {
+const transformMockAccounts = (accounts: ReturnType<typeof getAccounts>): MockAccount[] => {
+  return accounts.map((account, index) => {
     const institutionName = account.institutionName || 'Chase Bank';
     const institutionData = institutionName in mockInstitutions 
       ? mockInstitutions[institutionName as keyof typeof mockInstitutions]
@@ -77,10 +78,11 @@ const transformMockAccounts = (): MockAccount[] => {
   });
 };
 
-// Use all mock accounts when enabled
-const MOCK_ACCOUNTS: MockAccount[] = import.meta.env.VITE_USE_MOCK_ACCOUNTS === 'true' || import.meta.env.DEV
-  ? transformMockAccounts()
-  : [
+// Use accounts from provider with a small fallback when disabled
+const MOCK_ACCOUNTS: MockAccount[] = (() => {
+  const accs = transformMockAccounts(getAccounts());
+  if (accs.length > 0) return accs;
+  return [
       {
         id: 'acc_chase_checking_001',
         institution: {
@@ -144,8 +146,9 @@ const MOCK_ACCOUNTS: MockAccount[] = import.meta.env.VITE_USE_MOCK_ACCOUNTS === 
           date: '2024-01-14T14:22:00Z',
           pending: true,
         },
-      },
+      }
     ];
+})();
 
 const VISIBLE_COUNT = 5;
 

--- a/src/pages/CleanDashboard.tsx
+++ b/src/pages/CleanDashboard.tsx
@@ -27,91 +27,33 @@ import {
   EyeOff,
 } from 'lucide-react';
 import { OptimizedTransactionList } from '@/features/transactions/components/OptimizedTransactionList';
+import {
+  getAccounts,
+  getTransactions,
+} from '@/services/mockDataProvider';
 
-// Mock data that matches your existing structure
-const mockAccounts = [
-  {
-    id: 'acc_001',
-    accountType: 'Checking',
-    accountName: 'Main Account',
-    balance: 12450.0,
-    available: 11200.0,
-    change: { amount: 1523.5, percentage: 12.5, period: 'vs last month' },
-    isActive: true,
-  },
-  {
-    id: 'acc_002',
-    accountType: 'Savings',
-    accountName: 'Emergency Fund',
-    balance: 25780.5,
-    available: 25780.5,
-    change: { amount: 780.25, percentage: 3.1, period: 'vs last month' },
-  },
-  {
-    id: 'acc_003',
-    accountType: 'Credit Card',
-    accountName: 'Rewards Card',
-    balance: -1245.3,
-    available: 8754.7,
-    change: { amount: -245.3, percentage: -2.1, period: 'vs last month' },
-  },
-  {
-    id: 'acc_004',
-    accountType: 'Investment',
-    accountName: 'Portfolio',
-    balance: 45600.25,
-    available: 45600.25,
-    change: { amount: 2340.8, percentage: 5.4, period: 'vs last month' },
-  },
-];
+// Pull mock data from centralized provider
+const mockAccounts: AccountData[] = getAccounts().map((acc) => ({
+  id: acc.id,
+  accountType: acc.accountSubtype || acc.accountType,
+  accountName: acc.name,
+  balance: acc.balance,
+  available: acc.availableBalance,
+  change: { amount: 0, percentage: 0, period: 'vs last month' },
+  isActive: acc.isActive,
+}));
 
-const mockTransactions = [
-  {
-    id: 'txn_001',
-    merchant: 'Whole Foods Market',
-    category: 'Groceries',
-    amount: -127.43,
-    date: '2025-06-16T10:30:00Z',
-    status: 'completed' as const,
-    scores: { health: 85, eco: 92, financial: 78 },
-  },
-  {
-    id: 'txn_002',
-    merchant: 'Apple Store',
-    category: 'Electronics',
-    amount: -899.0,
-    date: '2025-06-16T08:15:00Z',
-    status: 'completed' as const,
-    scores: { health: 65, eco: 45, financial: 60 },
-  },
-  {
-    id: 'txn_003',
-    merchant: 'Salary Deposit',
-    category: 'Income',
-    amount: 3250.0,
-    date: '2025-06-15T09:00:00Z',
-    status: 'completed' as const,
-    scores: { health: 100, eco: 85, financial: 95 },
-  },
-  {
-    id: 'txn_004',
-    merchant: 'Starbucks',
-    category: 'Coffee',
-    amount: -6.85,
-    date: '2025-06-15T07:45:00Z',
-    status: 'completed' as const,
-    scores: { health: 40, eco: 60, financial: 85 },
-  },
-  {
-    id: 'txn_005',
-    merchant: 'Gas Station',
-    category: 'Transportation',
-    amount: -45.2,
-    date: '2025-06-14T18:30:00Z',
-    status: 'pending' as const,
-    scores: { health: 70, eco: 30, financial: 80 },
-  },
-];
+const mockTransactions = getTransactions().map((t) => ({
+  id: t.id,
+  merchant: (t as any).merchant ?? (t as any).merchantName ?? 'Unknown',
+  category: typeof (t as any).category === 'string'
+    ? (t as any).category
+    : (t as any).category?.name ?? 'Other',
+  amount: t.amount,
+  date: t.date,
+  status: (t as any).status ?? 'completed',
+  scores: { health: 0, eco: 0, financial: 0 },
+}));
 
 const DashboardMetric = ({
   title,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,7 +10,7 @@ import SavingsGoals from '@/features/savings/components/SavingsGoals';
 import CalculatorList from '@/features/calculators/components/CalculatorList';
 import { useIsMobile } from '@/shared/hooks/use-mobile';
 import { PerformanceMonitor } from '@/components/performance/PerformanceMonitor';
-import { mockData, getCompactAccountCards } from '@/services/mockData';
+import { getCompactAccountCards, getAccounts, getTransactions } from '@/services/mockDataProvider';
 import { usePrivacyStore } from '@/features/privacy-hide-amounts/store';
 import { Transaction } from '@/shared/types/shared';
 // CC: New Feature Cloud and Smart Accounts Deck imports
@@ -41,7 +41,6 @@ import { WidgetsPanel } from '@/features/widgets/components/WidgetsPanel';
 import { BiometricMonitorCard } from '@/features/biometric-intervention/components/BiometricMonitorCard';
 // Financial selectors for proper financial calculations
 import { selectTotalWealth } from '@/selectors/financialSelectors';
-import { mockAccountsEnhanced } from '@/services/mockData';
 import { formatCurrency } from '@/shared/utils/formatters';
 
 // Lazy load components properly without webpack comments
@@ -110,7 +109,7 @@ class ErrorBoundary extends React.Component<
 
 // Adapt mock transactions for new UI fields
 const adaptTransactions = (
-  transactions: typeof mockData.transactions
+  transactions: ReturnType<typeof getTransactions>
 ): Transaction[] => {
   // Helper to convert legacy transaction into full shape expected by UI
   const baseAdapted = transactions.map((t, idx) => {
@@ -297,7 +296,7 @@ export default function Index() {
   const isMobile = useIsMobile();
 
   // Calculate proper financial metrics using selectors
-  const netWorth = selectTotalWealth(mockAccountsEnhanced);
+  const netWorth = selectTotalWealth(getAccounts());
 
   // Data validation in useEffect instead of early return
   useEffect(() => {
@@ -420,7 +419,7 @@ export default function Index() {
             <div className="lg:col-span-2">
               <TransactionList
                 transactions={
-                  adaptTransactions(mockData.transactions)?.slice(0, 10) ||
+                  adaptTransactions(getTransactions())?.slice(0, 10) ||
                   []
                 }
                 isLoading={false}

--- a/src/services/mockDataProvider.ts
+++ b/src/services/mockDataProvider.ts
@@ -1,0 +1,14 @@
+import { mockData, mockAccountsEnhanced, getCompactAccountCards as baseGetCompactAccountCards } from './mockData';
+import type { Account, Transaction } from '@/shared/types/shared';
+import type { AccountCardDTO } from '@/shared/types/accounts';
+
+const useMocks = (): boolean =>
+  import.meta.env.VITE_USE_MOCK_ACCOUNTS === 'true' || import.meta.env.DEV;
+
+export const getAccounts = (): Account[] => (useMocks() ? mockAccountsEnhanced : []);
+
+export const getTransactions = (): Transaction[] =>
+  useMocks() ? (mockData.transactions as Transaction[]) : [];
+
+export const getCompactAccountCards = (): AccountCardDTO[] =>
+  useMocks() ? baseGetCompactAccountCards() : [];


### PR DESCRIPTION
## Summary
- add `mockDataProvider` for accounts and transactions
- update dashboard, bank linking panel, linked accounts card, and home page to load data via provider
- remove scattered mock data arrays and env checks

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c506bf0883289c64b668b3a58cc6