### PR TITLE
Fix back button alignment

### DIFF
--- a/src/features/credit/components/CreditScorePage.tsx
+++ b/src/features/credit/components/CreditScorePage.tsx
@@ -145,6 +145,7 @@ const CreditScorePage = () => {
             fallbackPath="/"
             variant="default"
             label="Back to Dashboard"
+            className="mb-6"
           />
 
           <div className="bg-white/[0.02] rounded-2xl sm:rounded-3xl border border-white/[0.08] p-6 sm:p-8 text-center">
@@ -168,6 +169,7 @@ const CreditScorePage = () => {
           fallbackPath="/"
           variant="default"
           label="Back to Dashboard"
+          className="mb-6"
         />
 
         {/* Header */}

--- a/src/pages/OptimizedProfile.tsx
+++ b/src/pages/OptimizedProfile.tsx
@@ -174,7 +174,7 @@ const OptimizedProfile = React.memo(() => {
         {/* Header with Navigation */}
         <div className="mb-8">
           {/* Back to Dashboard Button */}
-          <div className="flex items-center mb-4">
+          <div className="flex items-center mb-6">
             <button
               onClick={handleBackToDashboard}
               className="flex items-center space-x-2 text-white/70 hover:text-white transition-all duration-200 group cursor-pointer bg-transparent border-none outline-none focus:outline-none focus:ring-2 focus:ring-blue-500/50 rounded-lg p-2 -m-2"


### PR DESCRIPTION
## Summary
- standardize "Back to Dashboard" button margin on CreditScorePage
- adjust profile page header margin to match other pages

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f1b5614c8328a6c0e38bb23ea1c5