### PR TITLE
Replace inline colors with Vueni palette tokens

### DIFF
--- a/src/features/calculators/components/LoanCalculator.tsx
+++ b/src/features/calculators/components/LoanCalculator.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { getColor, applyOpacity } from '@/theme/vueniPalette';
 import { calculateLoanPayment } from '@/shared/utils/calculators';
 import GlassSlider from '@/shared/ui/GlassSlider';
 import {
@@ -83,8 +84,8 @@ const LoanCalculator = () => {
   const totalInterest = totalPayments - principal;
 
   const summaryData = [
-    { name: 'Principal', value: principal, color: '#3B82F6' },
-    { name: 'Interest', value: totalInterest, color: '#EF4444' },
+    { name: 'Principal', value: principal, color: getColor('palette.primary') },
+    { name: 'Interest', value: totalInterest, color: getColor('palette.danger') },
   ];
 
   const loanTypes = [
@@ -224,22 +225,22 @@ const LoanCalculator = () => {
                       x2="0"
                       y2="1"
                     >
-                      <stop offset="5%" stopColor="#3B82F6" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="#3B82F6" stopOpacity={0} />
+                      <stop offset="5%" stopColor={getColor('palette.primary')} stopOpacity={0.3} />
+                      <stop offset="95%" stopColor={getColor('palette.primary')} stopOpacity={0} />
                     </linearGradient>
                   </defs>
                   <CartesianGrid
                     strokeDasharray="3 3"
-                    stroke="rgba(255,255,255,0.1)"
+                    stroke={applyOpacity(getColor('text.primary'), 0.1)}
                   />
                   <XAxis
                     dataKey="year"
-                    stroke="#fff"
+                    stroke={getColor('text.primary')}
                     fontSize={12}
                     tickFormatter={(value) => `Year ${value}`}
                   />
                   <YAxis
-                    stroke="#fff"
+                    stroke={getColor('text.primary')}
                     fontSize={12}
                     tickFormatter={(value) => formatCurrency(value)}
                   />
@@ -250,16 +251,16 @@ const LoanCalculator = () => {
                     ]}
                     labelFormatter={(value) => `Year ${value}`}
                     contentStyle={{
-                      backgroundColor: 'rgba(0,0,0,0.8)',
-                      border: '1px solid rgba(255,255,255,0.2)',
+                      backgroundColor: applyOpacity(getColor('surface.background'), 0.8),
+                      border: `1px solid ${applyOpacity(getColor('text.primary'), 0.2)}`,
                       borderRadius: '12px',
-                      color: '#fff',
+                      color: getColor('text.primary'),
                     }}
                   />
                   <Area
                     type="monotone"
                     dataKey="balance"
-                    stroke="#3B82F6"
+                    stroke={getColor('palette.primary')}
                     fill="url(#balanceGradient)"
                     strokeWidth={2}
                   />
@@ -295,10 +296,10 @@ const LoanCalculator = () => {
                       'Amount',
                     ]}
                     contentStyle={{
-                      backgroundColor: 'rgba(0,0,0,0.8)',
-                      border: '1px solid rgba(255,255,255,0.2)',
+                      backgroundColor: applyOpacity(getColor('surface.background'), 0.8),
+                      border: `1px solid ${applyOpacity(getColor('text.primary'), 0.2)}`,
                       borderRadius: '12px',
-                      color: '#fff',
+                      color: getColor('text.primary'),
                     }}
                   />
                 </PieChart>
@@ -330,11 +331,11 @@ const LoanCalculator = () => {
               <BarChart data={loanTypes}>
                 <CartesianGrid
                   strokeDasharray="3 3"
-                  stroke="rgba(255,255,255,0.1)"
+                  stroke={applyOpacity(getColor('text.primary'), 0.1)}
                 />
-                <XAxis dataKey="type" stroke="#fff" fontSize={12} />
+                <XAxis dataKey="type" stroke={getColor('text.primary')} fontSize={12} />
                 <YAxis
-                  stroke="#fff"
+                  stroke={getColor('text.primary')}
                   fontSize={12}
                   tickFormatter={(value) => formatCurrency(value)}
                 />
@@ -344,13 +345,13 @@ const LoanCalculator = () => {
                     'Monthly Payment',
                   ]}
                   contentStyle={{
-                    backgroundColor: 'rgba(0,0,0,0.8)',
-                    border: '1px solid rgba(255,255,255,0.2)',
+                    backgroundColor: applyOpacity(getColor('surface.background'), 0.8),
+                    border: `1px solid ${applyOpacity(getColor('text.primary'), 0.2)}`,
                     borderRadius: '12px',
-                    color: '#fff',
+                    color: getColor('text.primary'),
                   }}
                 />
-                <Bar dataKey="payment" fill="#10B981" radius={[4, 4, 0, 0]} />
+                <Bar dataKey="payment" fill={getColor('palette.success')} radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/src/features/calculators/components/ROICalculator.tsx
+++ b/src/features/calculators/components/ROICalculator.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback } from 'react';
+import { getColor, applyOpacity } from '@/theme/vueniPalette';
 import { calculateROI } from '@/shared/utils/calculators';
 import {
   BarChart,
@@ -57,11 +58,11 @@ const ROICalculator = React.memo(() => {
   // Memoized pie chart data
   const pieData = useMemo(
     () => [
-      { name: 'Initial Investment', value: initial, color: '#3B82F6' },
+      { name: 'Initial Investment', value: initial, color: getColor('palette.primary') },
       {
         name: 'Gain/Loss',
         value: Math.max(0, current - initial),
-        color: '#10B981',
+        color: getColor('palette.success'),
       },
     ],
     [initial, current]
@@ -200,18 +201,18 @@ const ROICalculator = React.memo(() => {
                 <BarChart data={chartData}>
                   <CartesianGrid
                     strokeDasharray="3 3"
-                    stroke="rgba(255,255,255,0.1)"
+                    stroke={applyOpacity(getColor('text.primary'), 0.1)}
                   />
                   <XAxis
                     dataKey="investment"
-                    stroke="#fff"
+                    stroke={getColor('text.primary')}
                     fontSize={12}
                     angle={-45}
                     textAnchor="end"
                     height={60}
                   />
                   <YAxis
-                    stroke="#fff"
+                    stroke={getColor('text.primary')}
                     fontSize={12}
                     tickFormatter={(value) => formatCurrency(value)}
                   />
@@ -221,13 +222,13 @@ const ROICalculator = React.memo(() => {
                       'Amount',
                     ]}
                     contentStyle={{
-                      backgroundColor: 'rgba(0,0,0,0.8)',
-                      border: '1px solid rgba(255,255,255,0.2)',
+                      backgroundColor: applyOpacity(getColor('surface.background'), 0.8),
+                      border: `1px solid ${applyOpacity(getColor('text.primary'), 0.2)}`,
                       borderRadius: '12px',
-                      color: '#fff',
+                      color: getColor('text.primary'),
                     }}
                   />
-                  <Bar dataKey="amount" fill="#3B82F6" radius={[4, 4, 0, 0]} />
+                  <Bar dataKey="amount" fill={getColor('palette.primary')} radius={[4, 4, 0, 0]} />
                 </BarChart>
               </ResponsiveContainer>
             </div>
@@ -260,10 +261,10 @@ const ROICalculator = React.memo(() => {
                       'Amount',
                     ]}
                     contentStyle={{
-                      backgroundColor: 'rgba(0,0,0,0.8)',
-                      border: '1px solid rgba(255,255,255,0.2)',
+                      backgroundColor: applyOpacity(getColor('surface.background'), 0.8),
+                      border: `1px solid ${applyOpacity(getColor('text.primary'), 0.2)}`,
                       borderRadius: '12px',
-                      color: '#fff',
+                      color: getColor('text.primary'),
                     }}
                   />
                 </PieChart>

--- a/src/features/privacy-hide-amounts/components/PrivacyToggle.tsx
+++ b/src/features/privacy-hide-amounts/components/PrivacyToggle.tsx
@@ -3,6 +3,7 @@ import { Switch } from '@/shared/ui/switch';
 import { usePrivacyStore } from '../store';
 import { UniversalCard } from '@/shared/ui/UniversalCard';
 import { EyeOff } from 'lucide-react';
+import { getColor } from '@/theme/vueniPalette';
 
 export const PrivacyToggle: React.FC = () => {
   const hide = usePrivacyStore((s) => s.setting.hideAmounts);
@@ -14,7 +15,7 @@ export const PrivacyToggle: React.FC = () => {
       size="md"
       title="Privacy Settings"
       icon={EyeOff}
-      iconColor="#8b5cf6"
+      iconColor={getColor('semantic.chart.investments')}
     >
       <div className="flex items-center justify-between">
         <span className="text-sm text-white/70">Hide amounts</span>

--- a/src/features/smart-savings/components/SmartSavingsPanel.tsx
+++ b/src/features/smart-savings/components/SmartSavingsPanel.tsx
@@ -3,6 +3,7 @@ import { UniversalCard } from '@/shared/ui/UniversalCard';
 import { CreatePlanForm } from './CreatePlanForm';
 import { AutosavePlansList } from './AutosavePlansList';
 import { PiggyBank } from 'lucide-react';
+import { getColor } from '@/theme/vueniPalette';
 
 export const SmartSavingsPanel: React.FC = () => {
   return (
@@ -11,7 +12,7 @@ export const SmartSavingsPanel: React.FC = () => {
       size="md"
       title="Smart Automated Savings"
       icon={PiggyBank}
-      iconColor="#ec4899"
+      iconColor={getColor('charts.colors.extended.pink')}
     >
       <div className="space-y-4">
         <CreatePlanForm />

--- a/src/theme/vueniPalette.ts
+++ b/src/theme/vueniPalette.ts
@@ -1,0 +1,16 @@
+import { vueniTheme, getColor as unifiedGetColor } from './unified';
+
+export const vueniPalette = vueniTheme.colors;
+
+export const getColor = (path: string) => unifiedGetColor(path);
+
+export const applyOpacity = (hex: string, opacity: number): string => {
+  const normalized = hex.replace('#', '');
+  const bigint = parseInt(normalized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+};
+
+export default vueniPalette;


### PR DESCRIPTION
## Summary
- add `vueniPalette.ts` exposing `getColor` and `applyOpacity`
- convert hardcoded colors in PrivacyToggle, SmartSavingsPanel
- migrate several calculator components to use Vueni color tokens

## Testing
- `npm run lint` *(fails: cannot find module eslint)*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f079756c8328ab975bdb8321aeb3