### PR TITLE
Use CSS var tokens with data-theme support

### DIFF
--- a/src/app/styles/nav-styles.css
+++ b/src/app/styles/nav-styles.css
@@ -474,6 +474,7 @@
 }
 
 /* Explicit dark mode */
+[data-theme='dark'] .liquid-glass-nav,
 .dark .liquid-glass-nav {
   --nav-glass-primary: rgba(0, 0, 0, 0.3);
   --nav-glass-secondary: rgba(0, 0, 0, 0.4);

--- a/src/app/styles/responsive-enhancements.css
+++ b/src/app/styles/responsive-enhancements.css
@@ -150,7 +150,7 @@ textarea:focus-visible,
 
 /* Light Mode High Contrast */
 @media (prefers-contrast: high) {
-  html:not(.dark) {
+  [data-theme='light'], html:not(.dark) {
     --light-text-primary: rgb(0, 0, 0);
     --light-text-secondary: rgb(17, 24, 39);
     --light-bg-glass: rgba(255, 255, 255, 1);
@@ -198,11 +198,13 @@ textarea:focus-visible,
 }
 
 /* Color Contrast Improvements for Light Mode */
-html:not(.dark) {
+[data-theme='light'], html:not(.dark) {
   /* Ensure all text meets WCAG AA standards */
   color: var(--light-text-primary);
 }
 
+[data-theme='light'] .text-muted,
+[data-theme='light'] [class*='text-muted'],
 html:not(.dark) .text-muted,
 html:not(.dark) [class*='text-muted'] {
   color: var(--light-text-secondary) !important;
@@ -707,6 +709,7 @@ html:not(.dark) [class*='text-muted'] {
 }
 
 /* Dark mode toggle background */
+[data-theme='dark'] .ios26-toggle,
 .dark .ios26-toggle {
   background-color: rgba(107, 114, 128, 0.4); /* gray-500/40 */
 }
@@ -716,6 +719,7 @@ html:not(.dark) [class*='text-muted'] {
   background-color: #2563eb; /* blue-600 */
 }
 
+[data-theme='dark'] .ios26-toggle[data-state='checked'],
 .dark .ios26-toggle[data-state='checked'] {
   background-color: #3b82f6; /* blue-500 */
 }
@@ -735,6 +739,7 @@ html:not(.dark) [class*='text-muted'] {
 }
 
 /* Dark mode thumb shadow */
+[data-theme='dark'] .ios26-toggle-thumb,
 .dark .ios26-toggle-thumb {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@
     --radius: 0.5rem;
   }
 
-  .dark {
+  [data-theme='dark'], .dark {
     --background: 0 0% 0%;
     --foreground: 210 40% 98%;
 
@@ -168,6 +168,7 @@
 }
 
 /* Dark mode dropdown enhancements for consistency */
+[data-theme='dark'] [data-radix-dropdown-menu-content],
 html.dark [data-radix-dropdown-menu-content] {
   background: rgba(0, 0, 0, 0.95) !important;
   border: 2px solid rgba(255, 255, 255, 0.2) !important;
@@ -175,15 +176,18 @@ html.dark [data-radix-dropdown-menu-content] {
   backdrop-filter: blur(16px) !important;
 }
 
+[data-theme='dark'] [data-radix-dropdown-menu-item],
 html.dark [data-radix-dropdown-menu-item] {
   color: rgba(255, 255, 255, 0.9) !important;
 }
 
+[data-theme='dark'] [data-radix-dropdown-menu-item]:hover,
 html.dark [data-radix-dropdown-menu-item]:hover {
   background: rgba(255, 255, 255, 0.1) !important;
   color: rgb(255, 255, 255) !important;
 }
 
+[data-theme='dark'] [data-radix-dropdown-menu-item]:focus,
 html.dark [data-radix-dropdown-menu-item]:focus {
   background: rgba(255, 255, 255, 0.15) !important;
   color: rgb(255, 255, 255) !important;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -42,7 +42,7 @@ try {
   // In development, show a helpful error message
   if (import.meta.env.DEV) {
     document.body.innerHTML = `
-      <div style="background: #1a1a1a; color: #ff6b6b; padding: 2rem; font-family: var(--vueni-font-family); line-height: 1.6;">
+      <div style="background: var(--vueni-surface-bg, #1a1a1a); color: var(--vueni-danger, #ff6b6b); padding: 2rem; font-family: var(--vueni-font-family); line-height: 1.6;">
         <h1>🔒 Security Configuration Required</h1>
         <pre style="background: #2a2a2a; padding: 1rem; border-radius: 8px; overflow-x: auto;">
 ${errorMessage}
@@ -56,7 +56,8 @@ ${errorMessage}
   throw new Error('Security configuration error');
 }
 
-// Add dark mode class to document by default
+// Add dark mode attribute (with legacy class fallback)
+document.documentElement.setAttribute('data-theme', 'dark');
 document.documentElement.classList.add('dark');
 
 createRoot(document.getElementById('root')!).render(<App />);

--- a/src/shared/components/ui/chart.tsx
+++ b/src/shared/components/ui/chart.tsx
@@ -4,7 +4,10 @@ import * as RechartsPrimitive from 'recharts';
 import { cn } from '@/shared/lib/utils';
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: '', dark: '.dark' } as const;
+const THEMES = {
+  light: "[data-theme='light'], .light",
+  dark: "[data-theme='dark'], .dark",
+} as const;
 
 export type ChartConfig = {
   [k in string]: {

--- a/src/shared/ui/chart.tsx
+++ b/src/shared/ui/chart.tsx
@@ -4,7 +4,10 @@ import * as RechartsPrimitive from 'recharts';
 import { cn } from '@/shared/lib/utils';
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: '', dark: '.dark' } as const;
+const THEMES = {
+  light: "[data-theme='light'], .light",
+  dark: "[data-theme='dark'], .dark",
+} as const;
 
 export type ChartConfig = {
   [k in string]: {

--- a/src/test/theme-drift-detection.test.ts
+++ b/src/test/theme-drift-detection.test.ts
@@ -130,14 +130,14 @@ describe('Theme Drift Detection', () => {
         const cssContent = fs.readFileSync(indexCssPath, 'utf-8');
 
         // Should not contain light mode selectors
-        expect(cssContent).not.toMatch(/html:not\(\.dark\)/);
+        expect(cssContent).not.toMatch(/\[data-theme='light'\]/);
         expect(cssContent).not.toMatch(
           /:root\s*\{[^}]*--background:\s*0\s+0%\s+100%/
         );
         expect(cssContent).not.toMatch(/\.light/);
 
         // Should contain dark mode
-        expect(cssContent).toMatch(/\.dark/);
+        expect(cssContent).toMatch(/\[data-theme='dark'\]/);
       }
     });
 

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -56,8 +56,9 @@ export const VueniThemeProvider: React.FC<VueniThemeProviderProps> = ({
       rootElement.style.setProperty(property, value);
     });
 
-    // Ensure dark mode class is applied
-    rootElement.classList.add('dark');
+    // Ensure dark mode attribute/class are applied
+    rootElement.setAttribute('data-theme', 'dark');
+    rootElement.classList.add('dark'); // legacy fallback
     rootElement.classList.remove('light'); // Remove any light mode remnants
 
     // Set primary font family on body
@@ -68,6 +69,8 @@ export const VueniThemeProvider: React.FC<VueniThemeProviderProps> = ({
       Object.keys(cssProperties).forEach((property) => {
         rootElement.style.removeProperty(property);
       });
+      rootElement.removeAttribute('data-theme');
+      rootElement.classList.remove('dark');
     };
   }, [cssProperties]);
 


### PR DESCRIPTION
## Summary
- use `var(--vueni-*)` tokens in the startup security screen
- apply `[data-theme]` attribute in `ThemeProvider` and HTML
- support `[data-theme]` selectors in chart helpers and nav styles
- switch dropdown and responsive styles to `[data-theme]`
- update theme drift test expectations

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f07a1b748328855ebe8eb2bd9eaf