### PR TITLE
Fix /insights page background on desktop

### DIFF
--- a/src/features/insights/components/BaseInsightsPage.tsx
+++ b/src/features/insights/components/BaseInsightsPage.tsx
@@ -347,8 +347,8 @@ const BaseInsightsPage = ({
   );
 
   const containerClasses = compactMode
-    ? 'relative overflow-hidden p-4'
-    : 'relative overflow-hidden';
+    ? 'relative overflow-hidden p-4 min-h-screen bg-black text-white'
+    : 'relative overflow-hidden min-h-screen bg-black text-white';
 
   return (
     <div className={`${containerClasses} ${className}`}>


### PR DESCRIPTION
## Summary
- ensure `BaseInsightsPage` takes up the full viewport height so overlays span the entire page

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f23c80c48328b2aad5b450499b6c