### PR TITLE
Add consistent back navigation

### DIFF
--- a/src/pages/ChartDemo.tsx
+++ b/src/pages/ChartDemo.tsx
@@ -4,10 +4,17 @@
 
 import React from 'react';
 import GraphBaseDemo from '@/components/charts/GraphBase.demo';
+import { BackButton } from '@/shared/components/ui/BackButton';
 
 const ChartDemoPage: React.FC = () => {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-6 space-y-6">
+      <BackButton
+        fallbackPath="/"
+        variant="default"
+        label="Back to Dashboard"
+        className="mb-4"
+      />
       <GraphBaseDemo />
     </div>
   );

--- a/src/pages/InsightsPage.tsx
+++ b/src/pages/InsightsPage.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import BaseInsightsPage from '@/features/insights/components/BaseInsightsPage';
 import { MOCK_DATA } from '@/services/dataProvider';
 import { AgeOfMoneyCard } from '@/features/age-of-money/components/AgeOfMoneyCard';
+import BackHeader from '@/shared/ui/BackHeader';
 
 const InsightsPage = () => {
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Age of Money Metric */}
       <div className="px-4 sm:px-6 pt-4 sm:pt-6">
+        <BackHeader title="Insights" />
+      </div>
+      {/* Age of Money Metric */}
+      <div className="px-4 sm:px-6">
         <AgeOfMoneyCard />
       </div>
       

--- a/src/pages/MenuBarDemo.tsx
+++ b/src/pages/MenuBarDemo.tsx
@@ -21,6 +21,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/shared/ui/card';
+import { BackButton } from '@/shared/components/ui/BackButton';
 
 const MenuBarDemo = () => {
   const [selectedAction, setSelectedAction] = useState<string>('');
@@ -31,7 +32,13 @@ const MenuBarDemo = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative overflow-hidden">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative overflow-hidden p-6 space-y-6">
+      <BackButton
+        fallbackPath="/"
+        variant="default"
+        label="Back to Dashboard"
+        className="mb-4"
+      />
       {/* Background Effects */}
       <div className="absolute inset-0 bg-[url('data:image/svg+xml,%3Csvg%20width%3D%2260%22%20height%3D%2260%22%20viewBox%3D%220%200%2060%2060%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20fill%3D%22%239C92AC%22%20fill-opacity%3D%220.05%22%3E%3Ccircle%20cx%3D%2230%22%20cy%3D%2230%22%20r%3D%222%22/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')] opacity-40"></div>
 

--- a/src/pages/TransactionDemo.tsx
+++ b/src/pages/TransactionDemo.tsx
@@ -4,6 +4,7 @@ import MobileTransactionScreen from '@/screens/MobileTransactionScreen';
 import { Smartphone, Tablet, Monitor } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { SubscriptionsPanel } from '@/features/subscriptions/components/SubscriptionsPanel';
+import { BackButton } from '@/shared/components/ui/BackButton';
 
 const TransactionDemo: React.FC = () => {
   const [view, setView] = useState<'mobile' | 'tablet' | 'desktop'>('desktop');
@@ -147,6 +148,12 @@ const TransactionDemo: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-black p-8">
+      <BackButton
+        fallbackPath="/"
+        variant="default"
+        label="Back to Dashboard"
+        className="mb-8"
+      />
       {/* Header */}
       <div className="max-w-7xl mx-auto mb-8">
         <div className="flex items-center justify-between mb-8">


### PR DESCRIPTION
## Summary
- add BackHeader to Insights page
- add back buttons to ChartDemo, TransactionDemo and MenuBarDemo

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f2536ca8832897a8e46bf443cccd