### PR TITLE
Improve back navigation in OptimizedProfile

### DIFF
--- a/src/pages/OptimizedProfile.tsx
+++ b/src/pages/OptimizedProfile.tsx
@@ -137,8 +137,12 @@ const OptimizedProfile = React.memo(() => {
   );
 
   const handleBackToDashboard = useCallback(() => {
-    // Back to Dashboard navigation
-    navigate('/', { replace: true });
+    // Prefer navigating back if history is available
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate('/');
+    }
   }, [navigate]);
 
   // Memoized active section component


### PR DESCRIPTION
## Summary
- allow OptimizedProfile to navigate back with history

## Testing
- `npm run lint` *(fails: cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f37575088328b832cbf970d0d885