### PR TITLE
Fix new goal navigation

### DIFF
--- a/src/features/budget/components/BudgetPlannerPage.tsx
+++ b/src/features/budget/components/BudgetPlannerPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { budgetService } from '@/features/budget/api/budgetService';
 import { Budget, SavingsGoal } from '@/types/budgets';
 import BudgetTracker from './BudgetTracker';
@@ -17,8 +17,15 @@ import { useNavigate } from 'react-router-dom';
 import { cn } from '@/shared/lib/utils';
 import { BackButton } from '@/shared/components/ui/BackButton';
 
+// Hook to navigate to the Savings Goals page
+export const useNewGoalNavigation = () => {
+  const navigate = useNavigate();
+  return React.useCallback(() => navigate('/savings'), [navigate]);
+};
+
 const BudgetPlannerPage = () => {
   const navigate = useNavigate();
+  const handleNewGoalClick = useNewGoalNavigation();
   const [budget, setBudget] = useState<Budget | null>(null);
   const [goals, setGoals] = useState<SavingsGoal[]>([]);
   const [loading, setLoading] = useState(true);
@@ -98,7 +105,11 @@ const BudgetPlannerPage = () => {
           </p>
         </div>
         <div className="flex items-center gap-3 flex-wrap">
-          <button className="bg-green-500 hover:bg-green-600 text-white px-3 sm:px-4 py-2 rounded-xl transition-colors flex items-center gap-2 text-sm sm:text-base whitespace-nowrap">
+          <button
+            type="button"
+            onClick={handleNewGoalClick}
+            className="bg-green-500 hover:bg-green-600 text-white px-3 sm:px-4 py-2 rounded-xl transition-colors flex items-center gap-2 text-sm sm:text-base whitespace-nowrap"
+          >
             <Target className="w-4 h-4" />
             New Goal
           </button>


### PR DESCRIPTION
## Summary
- add a `useNewGoalNavigation` hook for the budget planner
- wire the "New Goal" button to navigate to `/savings`
- set the button type to `button`

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f36def388328abca7e8a169581f2