### PR TITLE
Wrap SavingsGoals page in black min-height container

### DIFF
--- a/src/pages/SavingsGoals/index.tsx
+++ b/src/pages/SavingsGoals/index.tsx
@@ -11,7 +11,7 @@ import { SmartSavingsPanel } from '@/features/smart-savings/components/SmartSavi
  */
 const SavingsGoalsPage: React.FC = () => {
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <div className="min-h-screen bg-black text-white space-y-4 sm:space-y-6">
       {/* Smart Automated Savings Plans */}
       <div className="px-4 sm:px-6 pt-4 sm:pt-6">
         <SmartSavingsPanel />


### PR DESCRIPTION
## Summary
- add page-wide container styling for SavingsGoals page

## Testing
- `npm run lint` *(fails: Cannot find module '/workspace/liquid-spark-finance/node_modules/eslint/bin/eslint.js')*
- `npm test` *(fails: vitest: not found)*
- `npm run test:e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3b8e3e8832891a51f42cdd38c6c