### PR TITLE
Refactor savings route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AdaptiveNavigation } from '@/navigation';
 import { ScrollControllerProvider } from '@/navigation/context/ScrollControllerContext';
 import { BiometricsProvider } from '@/providers/BiometricsProvider';
@@ -181,11 +181,16 @@ function App() {
                       path="/investment-tracker"
                       element={<InvestmentTrackerPage />}
                     />
-                    <Route path="/goal-setting" element={<SavingsGoals />} />
                     <Route path="/credit" element={<CreditScorePage />} />
                     <Route path="/savings" element={<SavingsGoals />} />
 
                     {/* Legacy Route Redirects */}
+                    {/* The old "/goal-setting" path now redirects to the canonical
+                        "/savings" route for backward compatibility. */}
+                    <Route
+                      path="/goal-setting"
+                      element={<Navigate to="/savings" replace />}
+                    />
                     <Route path="/credit-score" element={<CreditScorePage />} />
                   </Routes>
                 </Suspense>


### PR DESCRIPTION
## Summary
- consolidate `/goal-setting` into `/savings`
- redirect old goal-setting link to the new canonical path

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3bc2d008328818793f080020dd1