### PR TITLE
Fix chart typography sizes

### DIFF
--- a/src/theme/unified.ts
+++ b/src/theme/unified.ts
@@ -198,9 +198,9 @@ const chartSystem = {
     fontSize: {
       chartTitle: '20px',
       axisLabel: '12px',
-      dataLabel: '11px',
-      legend: '11px',
-      tooltip: '11px',
+      dataLabel: '12px',
+      legend: '12px',
+      tooltip: '12px',
     },
     fontWeight: {
       chartTitle: 600,


### PR DESCRIPTION
## Summary
- adjust chart token font sizes to 12px

## Testing
- `npm run lint` *(fails: cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_685700cf2c388328920b370f82495700