### PR TITLE
Add typography token file

### DIFF
--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,0 +1,31 @@
+/**
+ * Typography design tokens derived from the Vueni design specification.
+ * Defines the core font size scale and line height scale used across
+ * the application.
+ */
+
+export const fontSizes = {
+  xs: '0.75rem', // 12px
+  sm: '0.875rem', // 14px
+  base: '1rem', // 16px
+  lg: '1.125rem', // 18px
+  xl: '1.25rem', // 20px
+  '2xl': '1.5rem', // 24px
+  '3xl': '2rem', // 32px
+} as const;
+
+export const lineHeights = {
+  tight: 1.2,
+  normal: 1.4,
+  relaxed: 1.6,
+} as const;
+
+export type FontSize = keyof typeof fontSizes;
+export type LineHeight = keyof typeof lineHeights;
+
+const typography = {
+  fontSizes,
+  lineHeights,
+} as const;
+
+export default typography;

--- a/src/theme/unified.ts
+++ b/src/theme/unified.ts
@@ -15,6 +15,7 @@ import {
   VueniCharts,
   generateVueniCSSProperties,
 } from './colors/vueniPalette';
+import { fontSizes, lineHeights } from './typography';
 
 // Typography system - single font family
 const typographySystem = {
@@ -22,26 +23,14 @@ const typographySystem = {
     primary:
       '"SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
   },
-  fontSize: {
-    xs: '0.75rem', // 12px
-    sm: '0.875rem', // 14px
-    base: '1rem', // 16px
-    lg: '1.125rem', // 18px
-    xl: '1.25rem', // 20px
-    '2xl': '1.5rem', // 24px
-    '3xl': '2rem', // 32px
-  },
+  fontSize: fontSizes,
   fontWeight: {
     normal: 400,
     medium: 500,
     semibold: 600,
     bold: 700,
   },
-  lineHeight: {
-    tight: 1.2,
-    normal: 1.4,
-    relaxed: 1.6,
-  },
+  lineHeight: lineHeights,
 } as const;
 
 // Spacing system - 8px grid


### PR DESCRIPTION
## Summary
- implement `fontSizes` and `lineHeights` in `src/theme/typography.ts`
- consume these tokens from `unified.ts`

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685700cc7d4083288601db95759b8d0b