### PR TITLE
Add typography token snapshot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Welcome to the comprehensive documentation for the Vueni application. This docum
 - **[Refactoring Blueprint](./REFACTORING_BLUEPRINT.md)** - Comprehensive refactoring strategy and implementation plan
 - **[API Reference](./API_REFERENCE.md)** - Complete API documentation for all functions and services
 - **[Font Configuration](./guides/guide-font-configuration.md)** - Official font stack and CSS variables
+- **[Typography Snapshot](./typography-snapshot.md)** - Summary of font tokens and usage counts
 
 ### 🔒 Security
 

--- a/docs/typography-snapshot.md
+++ b/docs/typography-snapshot.md
@@ -1,0 +1,41 @@
+# Typography Token Snapshot
+
+This document catalogs all font-related tokens defined in the source tree and how many times each token appears across the `src/` and `docs/` directories. Occurrence counts were generated using `grep`.
+
+## Global Typography Tokens
+
+| Token | Count |
+| ----- | ----- |
+| `fontFamily.primary` | 11 |
+| `fontSize.xs` | 0 |
+| `fontSize.sm` | 0 |
+| `fontSize.base` | 0 |
+| `fontSize.lg` | 0 |
+| `fontSize.xl` | 0 |
+| `fontSize.2xl` | 0 |
+| `fontSize.3xl` | 0 |
+| `fontWeight.normal` | 0 |
+| `fontWeight.medium` | 0 |
+| `fontWeight.semibold` | 0 |
+| `fontWeight.bold` | 0 |
+| `lineHeight.tight` | 0 |
+| `lineHeight.normal` | 0 |
+| `lineHeight.relaxed` | 0 |
+| `--vueni-font-family` | 6 |
+
+## Chart Typography Tokens
+
+| Token | Count |
+| ----- | ----- |
+| `--chart-font-family` | 1 |
+| `--chart-font-size-title` | 1 |
+| `--chart-font-size-axis-label` | 1 |
+| `--chart-font-size-data-label` | 1 |
+| `--chart-font-size-legend` | 1 |
+| `--chart-font-size-tooltip` | 1 |
+| `--chart-font-weight-title` | 1 |
+| `--chart-font-weight-axis-label` | 1 |
+| `--chart-font-weight-data-label` | 1 |
+| `--chart-font-weight-legend` | 1 |
+| `--chart-font-weight-tooltip` | 1 |
+


### PR DESCRIPTION
## Summary
- document typography tokens in new docs/typography-snapshot.md
- link snapshot from docs index

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_685700d0f7808328b95d0443bff01ac8