### PR TITLE
Update font tokens in Tailwind config

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -514,3 +514,4 @@ html.dark [data-radix-dropdown-menu-item]:focus {
 }
 
 /* Remove duplicate import - already imported at top of file */
+@layer base { html { font-size: 16px; } }

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,0 +1,16 @@
+export const typography = {
+  fontSize: {
+    body: '1rem',
+    bodySmall: '0.875rem',
+    bodyLarge: '1.125rem',
+    heading1: '2rem',
+    heading2: '1.5rem',
+    heading3: '1.25rem',
+    heading4: '1.125rem',
+    heading5: '1rem',
+    heading6: '0.875rem',
+  },
+} as const;
+
+export type Typography = typeof typography;
+export default typography;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from 'tailwindcss';
 import tailwindcssAnimate from 'tailwindcss-animate';
+import { typography } from "./src/theme/typography";
 
 export default {
   darkMode: ['class'],
@@ -39,6 +40,17 @@ export default {
           'BlinkMacSystemFont',
           'sans-serif',
         ],
+      },
+      fontSize: {
+        body: typography.fontSize.body,
+        bodySmall: typography.fontSize.bodySmall,
+        bodyLarge: typography.fontSize.bodyLarge,
+        heading1: typography.fontSize.heading1,
+        heading2: typography.fontSize.heading2,
+        heading3: typography.fontSize.heading3,
+        heading4: typography.fontSize.heading4,
+        heading5: typography.fontSize.heading5,
+        heading6: typography.fontSize.heading6,
       },
       colors: {
         // Base shadcn colors (keeping for compatibility)


### PR DESCRIPTION
## Summary
- expose standard typography tokens
- consume those tokens inside `tailwind.config.ts`
- set base html font size

## Testing
- `npm run lint` *(fails: Cannot find module '/workspace/liquid-spark-finance/node_modules/eslint/bin/eslint.js')*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685700cd74c08328a61bf7d9f6cd6934