### PR TITLE
Refactor font sizes to tokens

### DIFF
--- a/src/app/styles/accessibility.css
+++ b/src/app/styles/accessibility.css
@@ -131,7 +131,7 @@
   text-decoration: none;
   border-radius: 4px;
   z-index: 1000;
-  font-size: 14px;
+  font-size: var(--fs-label);
   font-weight: 500;
   border: 2px solid #007aff;
 }
@@ -145,7 +145,7 @@
   border-collapse: collapse;
   width: 100%;
   margin-top: 1rem;
-  font-size: 14px;
+  font-size: var(--fs-label);
 }
 
 .chart-data-table th,
@@ -202,7 +202,7 @@
   color: #ffffff;
   padding: 4px 8px;
   border-radius: 4px;
-  font-size: 12px;
+  font-size: var(--fs-caption);
   white-space: nowrap;
   z-index: 100;
   pointer-events: none;

--- a/src/app/styles/card-alignment.css
+++ b/src/app/styles/card-alignment.css
@@ -36,7 +36,7 @@
 .category-nav-button .text-wrapper {
   text-align: center;
   line-height: 1.2;
-  font-size: 0.75rem;
+  font-size: var(--fs-label);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -97,7 +97,8 @@
   }
 
   .category-nav-button .text-wrapper {
-    font-size: 0.625rem !important;
+    font-size: var(--fs-caption) !important;
+    /* TODO: check caption mapping for 0.625rem */
   }
 }
 
@@ -131,17 +132,17 @@
 /* Mobile (up to 640px) */
 @media (max-width: 640px) {
   .liquid-glass-card h3 {
-    font-size: 1rem !important;
+    font-size: var(--fs-body) !important;
     line-height: 1.25 !important;
   }
 
   .liquid-glass-card h2 {
-    font-size: 1.25rem !important;
+    font-size: var(--fs-heading5) !important;
     line-height: 1.3 !important;
   }
 
   .category-nav-button .text-wrapper {
-    font-size: 0.625rem !important;
+    font-size: var(--fs-caption) !important;
     line-height: 1.1 !important;
   }
 }
@@ -149,17 +150,17 @@
 /* Tablet (641px - 1024px) */
 @media (min-width: 641px) and (max-width: 1024px) {
   .liquid-glass-card h3 {
-    font-size: 1.125rem !important;
+    font-size: var(--fs-body-lg) !important;
     line-height: 1.3 !important;
   }
 
   .liquid-glass-card h2 {
-    font-size: 1.5rem !important;
+    font-size: var(--fs-heading4) !important;
     line-height: 1.35 !important;
   }
 
   .category-nav-button .text-wrapper {
-    font-size: 0.75rem !important;
+    font-size: var(--fs-label) !important;
     line-height: 1.2 !important;
   }
 }
@@ -167,17 +168,17 @@
 /* Desktop (1025px+) */
 @media (min-width: 1025px) {
   .liquid-glass-card h3 {
-    font-size: 1.25rem !important;
+    font-size: var(--fs-heading5) !important;
     line-height: 1.4 !important;
   }
 
   .liquid-glass-card h2 {
-    font-size: 1.75rem !important;
+    font-size: var(--fs-heading3) !important;
     line-height: 1.4 !important;
   }
 
   .category-nav-button .text-wrapper {
-    font-size: 0.875rem !important;
+    font-size: var(--fs-label) !important; /* TODO: 0.875rem mapped to label */
     line-height: 1.3 !important;
   }
 }
@@ -275,7 +276,7 @@
 
 /* Collapsed card title fixes */
 .collapsed-card-title {
-  font-size: 1rem !important;
+  font-size: var(--fs-body) !important;
   line-height: 1.25 !important;
   margin-bottom: 0.5rem !important;
   white-space: nowrap;
@@ -284,7 +285,7 @@
 }
 
 .expanded-card-title {
-  font-size: 1.25rem !important;
+  font-size: var(--fs-heading5) !important;
   line-height: 1.4 !important;
   margin-bottom: 1rem !important;
   word-break: break-word;

--- a/src/app/styles/glass.css
+++ b/src/app/styles/glass.css
@@ -109,11 +109,11 @@
   }
 
   .transaction-merchant {
-    font-size: 15px;
+    font-size: var(--fs-body); /* TODO: 15px mapped to body */
   }
 
   .transaction-amount-text {
-    font-size: 15px;
+    font-size: var(--fs-body); /* TODO: 15px mapped to body */
   }
 }
 
@@ -126,19 +126,19 @@
   }
 
   .transaction-merchant {
-    font-size: 16px;
+    font-size: var(--fs-body);
   }
 
   .transaction-amount-text {
-    font-size: 16px;
+    font-size: var(--fs-body);
   }
 
   .transaction-category {
-    font-size: 13px;
+    font-size: var(--fs-caption); /* TODO: 13px approximated */
   }
 
   .transaction-date-text {
-    font-size: 13px;
+    font-size: var(--fs-caption); /* TODO: 13px approximated */
   }
 }
 
@@ -190,7 +190,7 @@
 }
 
 .transaction-merchant {
-  font-size: 14px;
+  font-size: var(--fs-label);
   font-weight: 500;
   line-height: 1.2;
   margin: 0 0 2px 0;
@@ -201,7 +201,7 @@
 }
 
 .transaction-category {
-  font-size: 12px;
+  font-size: var(--fs-caption);
   line-height: 1.2;
   margin: 0;
   color: rgba(255, 255, 255, 0.7);
@@ -211,7 +211,7 @@
 }
 
 .transaction-amount-text {
-  font-size: 14px;
+  font-size: var(--fs-label);
   font-weight: 600;
   line-height: 1.2;
   text-align: right;
@@ -219,7 +219,7 @@
 }
 
 .transaction-date-text {
-  font-size: 12px;
+  font-size: var(--fs-caption);
   line-height: 1.2;
   text-align: right;
   margin: 0;

--- a/src/app/styles/liquid-glass.css
+++ b/src/app/styles/liquid-glass.css
@@ -179,7 +179,7 @@
   border-radius: 12px;
   padding: 16px;
   color: white;
-  font-size: 14px;
+  font-size: var(--fs-label);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   transform: translateX(100%);
   transition: transform 0.3s ease;

--- a/src/app/styles/nav-styles.css
+++ b/src/app/styles/nav-styles.css
@@ -232,7 +232,7 @@
    ========================================================================== */
 
 .liquid-glass-nav-label {
-  font-size: 0.75rem;
+  font-size: var(--fs-label);
   font-weight: 500;
   line-height: 1;
   text-align: center;
@@ -346,7 +346,8 @@
   }
 
   .liquid-glass-nav-label {
-    font-size: 0.6875rem;
+    font-size: var(--fs-caption);
+    /* TODO: verify fs-caption mapping for 0.6875rem */
   }
 }
 

--- a/src/app/styles/performance-optimized.css
+++ b/src/app/styles/performance-optimized.css
@@ -216,7 +216,7 @@
   color: white;
   padding: 0.5rem;
   border-radius: 0.5rem;
-  font-size: 0.75rem;
+  font-size: var(--fs-label);
   z-index: 9999;
   font-family: var(--vueni-font-family);
 }

--- a/src/app/styles/responsive-enhancements.css
+++ b/src/app/styles/responsive-enhancements.css
@@ -894,25 +894,26 @@ html:not(.dark) [class*='text-muted'] {
    Typography System
    ============================================== */
 .responsive-heading {
-  font-size: 1.5rem;
+  font-size: var(--fs-heading4);
   line-height: 1.4;
 }
 
 @media (min-width: 768px) {
   .responsive-heading {
-    font-size: 1.75rem;
+    font-size: var(--fs-heading3);
   }
 }
 
 @media (min-width: 1024px) {
   .responsive-heading {
-    font-size: 2rem;
+    font-size: var(--fs-heading2);
   }
 }
 
 @media (min-width: 1440px) {
   .responsive-heading {
-    font-size: 2.25rem;
+    font-size: var(--fs-heading1);
+    /* TODO: confirm token mapping across breakpoints */
   }
 }
 
@@ -1035,18 +1036,18 @@ main,
    ============================================== */
 
 .collapsed-card-title {
-  font-size: 1rem !important;
+  font-size: var(--fs-body) !important;
   line-height: 1.3 !important;
 }
 
 @media (min-width: 1024px) {
   .collapsed-card-title {
-    font-size: 1.125rem !important;
+    font-size: var(--fs-body-lg) !important;
   }
 }
 
 .expanded-card-title {
-  font-size: 1.25rem !important;
+  font-size: var(--fs-heading5) !important;
   line-height: 1.4 !important;
   margin-bottom: 1rem !important;
   word-break: break-word;
@@ -1055,7 +1056,7 @@ main,
 
 @media (min-width: 1024px) {
   .expanded-card-title {
-    font-size: 1.5rem !important;
+    font-size: var(--fs-heading4) !important;
   }
 }
 
@@ -1259,12 +1260,12 @@ main,
   }
 
   .page-header-desktop h1 {
-    font-size: 2.5rem;
+    font-size: var(--fs-display);
     line-height: 1.2;
   }
 
   .page-header-desktop p {
-    font-size: 1.125rem;
+    font-size: var(--fs-body-lg);
     margin-top: 0.5rem;
   }
 }

--- a/src/navigation/styles/navigation-accessibility.css
+++ b/src/navigation/styles/navigation-accessibility.css
@@ -203,7 +203,7 @@
   color: #ffffff;
   padding: 6px 12px;
   border-radius: 6px;
-  font-size: 12px;
+  font-size: var(--fs-caption);
   white-space: nowrap;
   z-index: 1000;
   pointer-events: none;
@@ -268,7 +268,7 @@
   text-decoration: none;
   border-radius: 4px;
   z-index: 2000;
-  font-size: 14px;
+  font-size: var(--fs-label);
   font-weight: 500;
   border: 2px solid #007aff;
   transition: top 0.2s ease;
@@ -314,7 +314,8 @@
   background: #ff453a;
   color: #ffffff;
   border-radius: 50%;
-  font-size: 11px;
+  font-size: var(--fs-caption);
+  /* TODO: confirm fs-caption for 11px */
   font-weight: 600;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- replace hard-coded font sizes with `var(--fs-*)` tokens across navigation and app styles
- map unusual sizes to nearest token and add TODO comments

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685700ce4150832889fa8b6974e6185c